### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/jmf-pobox/xboing-python/security/code-scanning/3](https://github.com/jmf-pobox/xboing-python/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow, it only needs to read the repository contents (e.g., to check out the code). Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
<!--- START AUTOGENERATED NOTES --->
# Contents ([#13](https://github.com/jmf-pobox/xboing-python/pull/13))

### Other
- Workflow does not contain permissions

<!--- END AUTOGENERATED NOTES --->