### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: Tests
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/jmf-pobox/xboing-python/security/code-scanning/2](https://github.com/jmf-pobox/xboing-python/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- The `actions/checkout` step requires `contents: read` to fetch the repository code.
- The `codecov/codecov-action` step may require `contents: read` to upload the coverage report.

We will set `contents: read` as the only permission, as no other permissions are explicitly required by the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
<!--- START AUTOGENERATED NOTES --->
# Contents ([#14](https://github.com/jmf-pobox/xboing-python/pull/14))

### Other
- Workflow does not contain permissions

<!--- END AUTOGENERATED NOTES --->