### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,5 +1,7 @@
 name: Pylint
 on: [push]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jmf-pobox/xboing-python/security/code-scanning/1](https://github.com/jmf-pobox/xboing-python/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only performs linting tasks and does not require write access, we will set the permissions to `contents: read`. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
<!--- START AUTOGENERATED NOTES --->
# Contents ([#15](https://github.com/jmf-pobox/xboing-python/pull/15))

### Other
- Workflow does not contain permissions

<!--- END AUTOGENERATED NOTES --->