### PR TITLE
chore(deps): upgrade mypy, pyright, and ruff to latest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,9 @@ dependencies = [
     "pytest-cov",
     "pytest-timeout",
     # Code quality
-    "mypy>=1.18.1",
-    "pyright>=1.1.0",
-    "ruff>=0.13.0",
+    "mypy>=2.1.0",
+    "pyright>=1.1.410",
+    "ruff>=0.15.0",
     "black",
     "pylint",
     # Complexity metrics

--- a/src/xboing/scripts/normalize_audio.py
+++ b/src/xboing/scripts/normalize_audio.py
@@ -24,6 +24,7 @@ Notes:
     - Run this script after converting or adding new audio files to ensure all sounds are normalized.
 
 """
+
 import argparse
 import logging
 from pathlib import Path

--- a/src/xboing/scripts/normalize_audio.py
+++ b/src/xboing/scripts/normalize_audio.py
@@ -11,11 +11,11 @@ Purpose:
     This script should be run after converting or adding new audio files to the project.
 
 Usage:
-    python scripts/normalize_audio.py --input <input_dir> --output <output_dir>
+    python -m xboing.scripts.normalize_audio --input <input_dir> --output <output_dir>
     (Defaults: input=assets/sounds, output=assets/sounds/normalized)
 
 Dependencies:
-    - Python 3.7+
+    - Python 3.10+
     - ffmpeg (must be installed and available in your PATH)
 
 Notes:


### PR DESCRIPTION
## Summary
- Upgrades mypy from >=1.18.1 to >=2.1.0
- Upgrades pyright from >=1.1.0 to >=1.1.410
- Upgrades ruff from >=0.13.0 to >=0.15.0
- Applies black 26 formatting fix in normalize_audio.py (single blank line after docstring)

All quality gates pass with the upgraded tools — no new type errors or lint violations.

## Test plan
- [ ] `hatch run check` passes locally (lint, format, mypy, pyright, 202 tests)
- [ ] CI passes on Python 3.10, 3.11, 3.12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation-only changes with no runtime game logic or security impact.
> 
> **Overview**
> Bumps **mypy**, **pyright**, and **ruff** minimum versions in the Hatch default dev environment (`pyproject.toml`) so local/CI quality gates use the newer tool releases.
> 
> Updates **`normalize_audio.py`** docs to recommend `python -m xboing.scripts.normalize_audio`, documents **Python 3.10+**, and adds a blank line after the module docstring to satisfy **black 26** formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1662935a79aae238e1da5475d75aa386bf8b57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!--- START AUTOGENERATED NOTES --->
# Contents ([#34](https://github.com/jmf-pobox/xboing-python/pull/34))

### Other
- upgrade mypy, pyright, and ruff to latest
- fix outdated docstring in normalize_audio.py

<!--- END AUTOGENERATED NOTES --->