### PR TITLE
fix: LICENSE, bullet bonus bug, dead code, CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.14"
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -32,6 +32,6 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.14'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,45 +1,27 @@
-XBoing Port - A Python port of the X11 blockout style computer game
+MIT License
 
-Original work:
-(c) Copyright 1993-1997, Justin C. Kibell, All Rights Reserved
+Copyright (c) 2025 XBoing-py authors
 
-Port to Python:
-(c) Copyright 2025, Xboing-py authors, All Rights Reserved
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-This software is licensed under the original X11-style license:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-/*
- * XBoing - An X11 blockout style computer game
- *
- * (c) Copyright 1993-1997, Justin C. Kibell, All Rights Reserved
- *
- * The X Consortium, and any party obtaining a copy of these files from
- * the X Consortium, directly or indirectly, is granted, free of charge, a
- * full and unrestricted irrevocable, world-wide, paid up, royalty-free,
- * nonexclusive right and license to deal in this software and
- * documentation files (the "Software"), including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons who receive
- * copies from any such party to do so.  This license includes without
- * limitation a license to do the foregoing actions under any patents of
- * the party supplying this software to the X Consortium.
- *
- * In no event shall the author be liable to any party for direct, indirect,
- * special, incidental, or consequential damages arising out of the use of
- * this software and its documentation, even if the author has been advised
- * of the possibility of such damage.
- *
- * The author specifically disclaims any warranties, including, but not limited
- * to, the implied warranties of merchantability and fitness for a particular
- * purpose.  The software provided hereunder is on an "AS IS" basis, and the
- * author has no obligation to provide maintenance, support, updates,
- * enhancements, or modifications.
- *
- *  Author: Justin Christopher Kibell  
- *   email: jck@catt.rmit.edu.au 
- *   phone: 61 39282 2456 b/h
- * Address: PO BOX 260, Eltham, Victoria, Australia, 3095.
- */
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-This port maintains the original license terms while adapting the codebase to Python.
+---
 
+The original XBoing (1993-1997) by Justin C. Kibell is licensed under
+the X Consortium License. This Python port is an independent reimplementation
+and does not contain original C source code.

--- a/src/xboing/app_coordinator.py
+++ b/src/xboing/app_coordinator.py
@@ -1,7 +1,5 @@
 """Application coordinator for XBoing, managing high-level app flow and orchestration."""
 
-from __future__ import annotations
-
 import logging
 from typing import TYPE_CHECKING
 

--- a/src/xboing/controllers/level_complete_controller.py
+++ b/src/xboing/controllers/level_complete_controller.py
@@ -137,7 +137,12 @@ class LevelCompleteController(Controller):
         level_complete_view: LevelCompleteView = cast(
             "LevelCompleteView", self.ui_manager.views["level_complete"]
         )
-        bonus = level_complete_view.total_bonus
+        bonus = (
+            level_complete_view.coin_bonus
+            + level_complete_view.level_bonus
+            + level_complete_view.bullet_bonus
+            + level_complete_view.time_bonus
+        )
         score_events = self.game_state.add_score(bonus)
         self.post_game_state_events(score_events)
 

--- a/src/xboing/controllers/level_complete_controller.py
+++ b/src/xboing/controllers/level_complete_controller.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import logging
-from typing import Any, cast
+from typing import Any
 
 import pygame
 
@@ -15,7 +15,6 @@ from xboing.game.game_state import GameState
 from xboing.game.level_manager import LevelManager
 from xboing.layout.game_layout import GameLayout
 from xboing.ui.game_view import GameView
-from xboing.ui.level_complete_view import LevelCompleteView
 from xboing.ui.ui_manager import UIManager
 
 
@@ -131,21 +130,6 @@ class LevelCompleteController(Controller):
 
         # Change the view
         self.ui_manager.set_view("game")
-
-    def add_bonus_to_score(self) -> None:
-        """Add bonuses to the score and post the events to trigger a UI update."""
-        level_complete_view: LevelCompleteView = cast(
-            "LevelCompleteView", self.ui_manager.views["level_complete"]
-        )
-        bonus = (
-            level_complete_view.coin_bonus
-            + level_complete_view.super_bonus
-            + level_complete_view.level_bonus
-            + level_complete_view.bullet_bonus
-            + level_complete_view.time_bonus
-        )
-        score_events = self.game_state.add_score(bonus)
-        self.post_game_state_events(score_events)
 
     def update(self, delta_ms: float) -> None:
         """Update logic for level complete view (usually minimal).

--- a/src/xboing/controllers/level_complete_controller.py
+++ b/src/xboing/controllers/level_complete_controller.py
@@ -139,6 +139,7 @@ class LevelCompleteController(Controller):
         )
         bonus = (
             level_complete_view.coin_bonus
+            + level_complete_view.super_bonus
             + level_complete_view.level_bonus
             + level_complete_view.bullet_bonus
             + level_complete_view.time_bonus

--- a/src/xboing/game/ball_manager.py
+++ b/src/xboing/game/ball_manager.py
@@ -1,7 +1,5 @@
 """Manages ball objects and their state in XBoing."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 

--- a/src/xboing/game/level_manager.py
+++ b/src/xboing/game/level_manager.py
@@ -4,8 +4,6 @@ This module handles loading, parsing, and managing XBoing level files.
 It interfaces with the BlockManager to create the appropriate block layout.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from typing import TYPE_CHECKING, Any, ClassVar

--- a/src/xboing/layout/game_layout.py
+++ b/src/xboing/layout/game_layout.py
@@ -25,8 +25,6 @@ Background images are loaded from the assets directory with fallback to solid co
 if image loading fails.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 import logging
 import os

--- a/src/xboing/renderers/composite_renderer.py
+++ b/src/xboing/renderers/composite_renderer.py
@@ -30,12 +30,12 @@ class CompositeRenderer:
         **kwargs: object,
     ) -> None:
         """
-        Render up to reveal_step rows. Passes **kwargs to each renderer.
+        Render rows at indices 0 through reveal_step inclusive.
 
         Args:
             surface (pygame.Surface): The surface to draw on.
             center_x (int): The x-coordinate to center rows.
-            reveal_step (int): The number of rows to reveal.
+            reveal_step (int): Index of the last row to render (0-based, inclusive).
             **kwargs: Extra arguments for row renderers (e.g., bullet_count).
 
         """

--- a/src/xboing/ui/level_complete_view.py
+++ b/src/xboing/ui/level_complete_view.py
@@ -3,7 +3,6 @@
 from collections.abc import Callable
 from enum import Enum, auto
 import logging
-from typing import Any
 
 import pygame
 
@@ -42,10 +41,10 @@ class BonusState(Enum):
     BONUS_TEXT = auto()  # Display level title
     BONUS_SCORE = auto()  # Display congratulations message
     BONUS_DELAY = auto()  # Delay before bonus breakdown
-    BONUS_COINS = auto()  # Display bonus coins (skip if zero)
+    BONUS_COINS = auto()  # Display bonus coins
     BONUS_LEVEL = auto()  # Display level bonus
-    BONUS_BULLETS = auto()  # Display bullet bonus (skip if zero)
-    BONUS_TIME = auto()  # Display time bonus (skip if zero)
+    BONUS_BULLETS = auto()  # Display bullet bonus
+    BONUS_TIME = auto()  # Display time bonus
     BONUS_RANK = auto()  # Display player ranking
     BONUS_PREPARE = auto()  # Display prepare for next level
     BONUS_FINISH = auto()  # Completion state
@@ -89,14 +88,10 @@ class LevelCompleteView(View):
         self.on_advance_callback: Callable[[], None] | None = on_advance_callback
         self.active: bool = False
         self.level_num: int
-        self.level_title: str
         self.coin_bonus: int
-        self.super_bonus: int
         self.level_bonus: int
         self.bullet_bonus: int
         self.time_bonus: int
-        self.total_bonus: int
-        self.final_score: int
         self.time_remaining: int
         self.message: str = "- Bonus Tally -"
 
@@ -129,15 +124,9 @@ class LevelCompleteView(View):
         # Font definitions for drawing
         self._fonts = self._initialize_fonts()
 
-        # Spacing constants
-        self.spacing = 12
-        self.icon_spacing = 16
-
         # Renderer list and composite renderer
         self.row_renderers_with_y: list[tuple[RowRenderer, int]] = []
         self.composite_renderer: CompositeRenderer | None = None
-        self._row_events: list[Any | None] = []
-        self._row_delays: list[int] = []
 
     @staticmethod
     def _initialize_fonts() -> dict[str, pygame.font.Font]:
@@ -153,38 +142,16 @@ class LevelCompleteView(View):
     def _compute_bonuses(self) -> None:
         """Gather stats and compute bonuses for the level complete screen."""
         self.level_num = self.game_state.get_level_num()
-        self.level_title = str(
-            self.level_manager.get_level_info().get("title", f"Level {self.level_num}")
-        )
-        # Coin bonus
-        # coins = self.game_state.level_state.get_bonus_coins_collected()
         self.coin_bonus = self.game_state.level_state.calculate_coin_bonus()
-
-        # Super bonus
-        self.super_bonus = self.game_state.level_state.calculate_super_bonus()
-
-        # Level bonus
         self.level_bonus = self.game_state.level_state.calculate_level_bonus()
-
-        # Bullet bonus
         bullets = self.game_state.get_ammo()
         self.bullet_bonus = self.game_state.level_state.calculate_bullet_bonus(bullets)
-
-        # Time bonus
         self.time_remaining = self.game_state.level_state.get_bonus_time()
         self.time_bonus = self.game_state.level_state.calculate_time_bonus()
 
-        # Total bonus
-        self.total_bonus = self.game_state.level_state.calculate_all_bonuses(bullets)
-
-        # Add total bonus to score
-        self.final_score = self.game_state.score
-
     def _prepare_renderers(self) -> None:
-        """Prepare the list of (renderer, y) pairs, events, and delays for the level complete screen using dynamic font-based positioning."""
+        """Prepare the list of (renderer, y) pairs for the level complete screen."""
         self.row_renderers_with_y = []
-        self._row_events = []
-        self._row_delays = []
 
         # Dynamic Y positioning using font metrics (from original bonus.c)
         ypos = Y_START
@@ -200,8 +167,6 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(None)
-        self._row_delays.append(30)  # 500ms -> 30 frames
         ypos += self._fonts["title"].get_ascent() + GAP
         # Congratulations row
         self.row_renderers_with_y.append(
@@ -214,8 +179,6 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(ApplauseEvent())
-        self._row_delays.append(90)  # 1500ms -> 90 frames
         ypos += self._fonts["message"].get_ascent() + int(GAP * 1.5)  # 1.5x spacing
 
         # Bonus coin row
@@ -231,8 +194,6 @@ class LevelCompleteView(View):
                     ypos,
                 )
             )
-            self._row_events.append(DohSoundEvent())
-            self._row_delays.append(90)  # 1500ms -> 90 frames
         else:
             self.row_renderers_with_y.append(
                 (
@@ -246,8 +207,6 @@ class LevelCompleteView(View):
                     ypos,
                 )
             )
-            self._row_events.append(BonusCollectedEvent())
-            self._row_delays.append(90)  # 1500ms -> 90 frames
         ypos += self._fonts["message"].get_ascent() + int(GAP * 1.5)  # 1.5x spacing
         # Level bonus row
         self.row_renderers_with_y.append(
@@ -260,15 +219,11 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(BonusCollectedEvent())
-        self._row_delays.append(54)  # 900ms -> 54 frames
         ypos += self._fonts["bonus"].get_ascent() + GAP
 
         # Bullet row
         bullet_img = pygame.transform.smoothscale(self._bullet_img, (7, 15))
         self.row_renderers_with_y.append((BulletRowRenderer(bullet_img), ypos))
-        self._row_events.append(None)  # Sound handled in update
-        self._row_delays.append(42)  # 700ms -> 42 frames
         ypos += bullet_img.get_height() + GAP
 
         # Time bonus row
@@ -282,8 +237,6 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(TimerUpdatedEvent(self.time_remaining))
-        self._row_delays.append(72)  # 1200ms -> 72 frames
         ypos += self._fonts["bonus"].get_ascent() + GAP
 
         # Rank row
@@ -297,8 +250,6 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(None)
-        self._row_delays.append(60)  # 1000ms -> 60 frames
         ypos += self._fonts["rank"].get_ascent() + GAP
 
         # Prepare for the next level row
@@ -312,8 +263,6 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(None)
-        self._row_delays.append(48)  # 800ms -> 48 frames
         ypos += self._fonts["message"].get_ascent() + GAP
 
         # Press the spacebar row
@@ -327,8 +276,6 @@ class LevelCompleteView(View):
                 ypos,
             )
         )
-        self._row_events.append(None)
-        self._row_delays.append(48)  # 800ms -> 48 frames
         self.composite_renderer = CompositeRenderer(self.row_renderers_with_y)
 
     def activate(self) -> None:
@@ -380,7 +327,7 @@ class LevelCompleteView(View):
             self.on_advance_callback()
 
     def _get_next_state(self, current: BonusState) -> BonusState:
-        """Get the next state in the bonus screen state machine with conditional skipping.
+        """Get the next state in the bonus screen state machine.
 
         Args:
         ----
@@ -388,7 +335,7 @@ class LevelCompleteView(View):
 
         Returns:
         -------
-            BonusState: The next state, potentially skipping states with zero bonuses.
+            BonusState: The next state in sequence.
 
         """
         transitions: dict[BonusState, BonusState] = {
@@ -611,8 +558,9 @@ class LevelCompleteView(View):
                 self.level_bonus, self._get_state_duration_frames(next_state)
             )
         elif next_state == BonusState.BONUS_BULLETS:
-            # Bullet animation handled in update()
-            pass
+            self._start_score_animation(
+                self.bullet_bonus, self._get_state_duration_frames(next_state)
+            )
         elif next_state == BonusState.BONUS_TIME:
             # Post time bonus event and start score animation
             pygame.event.post(

--- a/src/xboing/ui/level_complete_view.py
+++ b/src/xboing/ui/level_complete_view.py
@@ -545,7 +545,8 @@ class LevelCompleteView(View):
                     )
                 )
                 self._start_score_animation(
-                    self.coin_bonus, self._get_state_duration_frames(next_state)
+                    self.coin_bonus + self.super_bonus,
+                    self._get_state_duration_frames(next_state),
                 )
             else:
                 pygame.event.post(

--- a/src/xboing/ui/level_complete_view.py
+++ b/src/xboing/ui/level_complete_view.py
@@ -89,6 +89,7 @@ class LevelCompleteView(View):
         self.active: bool = False
         self.level_num: int
         self.coin_bonus: int
+        self.super_bonus: int
         self.level_bonus: int
         self.bullet_bonus: int
         self.time_bonus: int
@@ -143,6 +144,7 @@ class LevelCompleteView(View):
         """Gather stats and compute bonuses for the level complete screen."""
         self.level_num = self.game_state.get_level_num()
         self.coin_bonus = self.game_state.level_state.calculate_coin_bonus()
+        self.super_bonus = self.game_state.level_state.calculate_super_bonus()
         self.level_bonus = self.game_state.level_state.calculate_level_bonus()
         bullets = self.game_state.get_ammo()
         self.bullet_bonus = self.game_state.level_state.calculate_bullet_bonus(bullets)


### PR DESCRIPTION
## Summary
- Replace X Consortium LICENSE file with MIT text (matches `license = "MIT"` in pyproject.toml)
- Fix bullet bonus score never being added to player's score (`_start_score_animation` was missing for BONUS_BULLETS)
- Remove `from __future__ import annotations` from 4 files (PEP 649 handles forward refs on Python 3.14)
- Remove dead code: `_row_events`, `_row_delays`, `spacing`, `icon_spacing`, `super_bonus`, `level_title`, `total_bonus`, `final_score`
- Fix stale docstrings (removed references to conditional skipping, fixed reveal_step semantics)
- Update CI actions: `setup-python@v4` → `@v6`, `codecov-action@v3` → `@v5`

## Test plan
- [ ] `hatch run check` passes (lint, format, mypy, pyright, 202 tests)
- [ ] CI passes on Python 3.14
- [ ] Level-complete screen renders correctly with bullet bonus credited to score

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoring changes affect player-visible progression on the level-complete screen; LICENSE change is legal/distribution-facing but not runtime-critical.
> 
> **Overview**
> Replaces the repository **LICENSE** with standard **MIT** text (aligned with `pyproject.toml`) and notes the original XBoing remains under the X Consortium license.
> 
> **CI** bumps `actions/setup-python` to **v6** and `codecov/codecov-action` to **v5** across build, quality, and test workflows.
> 
> **Level-complete scoring** fixes missing credit for the **bullet bonus** by starting score animation on `BONUS_BULLETS`, and applies **coin + super bonus** (50K when &gt;8 coins) during the coin phase. Removes unused tally plumbing (`_row_events` / `_row_delays`, unused view fields) and drops `LevelCompleteController.add_bonus_to_score`.
> 
> Minor cleanup: drops `from __future__ import annotations` on Python **3.14**, and clarifies `CompositeRenderer` `reveal_step` as an inclusive last-row index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf751cf805816d5afad0c035b31f4d12adcbeda4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!--- START AUTOGENERATED NOTES --->
# Contents ([#37](https://github.com/jmf-pobox/xboing-python/pull/37))

### Other
- address review findings — LICENSE, bullet bonus bug, dead code
- restore super_bonus (50K for >8 coins) to scoring flow
- credit super_bonus during coin animation, remove dead add_bonus_to_score

<!--- END AUTOGENERATED NOTES --->