### PR TITLE
docs: remove hardcoded test counts and stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 > **"If it doesn't pass all quality gates, it doesn't get committed."**
 
 Every commit must pass:
-1. All tests (170+ passing)
+1. All tests passing
 2. Type checking (mypy + pyright strict)
 3. Linting (ruff)
 4. Formatting (black)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ See [PLAN.md](PLAN.md) for detailed roadmap.
 
 From conversation and codebase:
 1. ✅ Clean, maintainable architecture over quick hacks
-2. ✅ Comprehensive testing with full coverage targets
+2. ✅ Comprehensive testing (target: 90% coverage)
 3. ✅ Protocol-based design for flexibility
 4. ✅ Micro-commits with quality gates
 5. ✅ Zero tolerance for type errors or lint violations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ hatch run lint           # 1. ZERO Ruff violations (src/ only)
 hatch run format         # 2. Perfect formatting (src/ only)
 hatch run type           # 3. ZERO MyPy errors (src/ only, strict mode)
 hatch run type-pyright   # 4. ZERO Pyright errors (src/ only, strict mode)
-hatch run test           # 5. ALL tests pass (currently 170 tests)
+hatch run test           # 5. ALL tests pass
 ```
 
 **Test Code (tests/) - Fix Gradually:**
@@ -153,7 +153,6 @@ hatch run cov-game-html  # Run game with coverage, generate HTML
 - Test individual components in isolation
 - Mock dependencies
 - Fast execution
-- Currently: 170 tests
 
 **Integration tests**: `tests/integration/`
 - Test interactions between components
@@ -217,7 +216,7 @@ See [PLAN.md](PLAN.md) for detailed roadmap.
 
 From conversation and codebase:
 1. ✅ Clean, maintainable architecture over quick hacks
-2. ✅ Comprehensive testing (170 tests and growing)
+2. ✅ Comprehensive testing with full coverage targets
 3. ✅ Protocol-based design for flexibility
 4. ✅ Micro-commits with quality gates
 5. ✅ Zero tolerance for type errors or lint violations
@@ -311,10 +310,10 @@ hatch run count-lines
 
 ### After Each Phase:
 
-1. **Phase completed**: e.g., "Phase 3: GameStateManager extraction"
-2. **Test count**: e.g., "170 tests passing"
-3. **Code metrics**: e.g., "GameController reduced from 479 to 473 lines"
-4. **Coverage**: e.g., "60% coverage (target: 90%)"
+1. **Phase completed**: name and scope
+2. **Tests**: all passing (`hatch run test`)
+3. **Quality gates**: all clean (`hatch run check`)
+4. **Coverage**: report via `hatch run test-cov`
 
 ## Session Management
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ To be added:
 
 Originally developed for X11 in C, XBoing was designed for speed and fun, with a focus on colorful visuals and responsive controls. This Python port faithfully recreates the original experience while adding modern compatibility.
 
+### Requirements
+
+- Python 3.14+
+- pygame
+
 ### Installation & Playing
 
 #### 1. Install from PyPI (Recommended)

--- a/STATUS.md
+++ b/STATUS.md
@@ -759,7 +759,6 @@ dependencies = [
 
 ### Missing Dependencies?
 Potential future need for:
-- `typing_extensions` for Python <3.10 protocol support (currently requires 3.10+)
 - `pytest-asyncio` if async tests added
 
 ---


### PR DESCRIPTION
## Summary
- Remove hardcoded "170 tests" from CLAUDE.md (test counts belong in CI output, not docs)
- Remove stale typing_extensions reference from STATUS.md (no longer a dependency)

## Test plan
- [ ] CI passes (docs-only, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, CI logic, or dependency updates beyond documentation text.
> 
> **Overview**
> Documentation-only cleanup so contributor and status docs do not go stale as the test suite grows.
> 
> **`CLAUDE.md`** drops the fixed **"170 tests"** wording from quality gates, unit-test notes, user preferences, and the quality philosophy. Those sections now say tests must **all pass** and point at **`hatch run test`** / **`hatch run test-cov`** instead of embedding a count. Phase-completion reporting is generalized (phase name, passing tests, **`hatch run check`**, coverage via **`test-cov`**).
> 
> **`README.md`** adds a short **Requirements** block (**Python 3.14+**, **pygame**) for players installing from PyPI or source.
> 
> **`STATUS.md`** removes the obsolete **`typing_extensions`** note under missing dependencies (no longer relevant for the supported Python version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933d1bd6e7a9f09be9a6be7e01aaac212f51acf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!--- START AUTOGENERATED NOTES --->
# Contents ([#38](https://github.com/jmf-pobox/xboing-python/pull/38))

### Other
- remove hardcoded test counts and stale references
- remove last hardcoded test count from CLAUDE.md
- clarify coverage target in CLAUDE.md preferences

<!--- END AUTOGENERATED NOTES --->